### PR TITLE
Custom color schemas

### DIFF
--- a/views/partials/colorscheme.ejs
+++ b/views/partials/colorscheme.ejs
@@ -34,6 +34,17 @@ if (currentScheme == "blue") {
     colone = "#2152ff";
     coltwo = "#21d4fd";
 }
+if (currentScheme == "custom") {
+    if (!themeConfig.themeColors || !themeConfig.themeColors.primarayColor || !themeConfig.themeColors.secondaryColor) {
+        currentCode = "310deg, #7928CA 0%, #FF0080 100%";
+        colone = "#FF0080";
+        coltwo = "#7928CA";
+    } else {
+        currentCode = "310deg, " + themeConfig.themeColors.primarayColor + " 0%, " + themeConfig.themeColors.secondaryColor + " 100%";
+        colone = themeConfig.themeColors.primarayColor;
+        coltwo = themeConfig.themeColors.secondaryColor;
+    }
+}
 %>
 <meta name="theme-color" content="<%- colone %>">
 <style>

--- a/views/partials/colorscheme.ejs
+++ b/views/partials/colorscheme.ejs
@@ -34,17 +34,6 @@ if (currentScheme == "blue") {
     colone = "#2152ff";
     coltwo = "#21d4fd";
 }
-if (currentScheme == "custom") {
-    if (!themeConfig.themeColors || !themeConfig.themeColors.primarayColor || !themeConfig.themeColors.secondaryColor) {
-        currentCode = "310deg, #7928CA 0%, #FF0080 100%";
-        colone = "#FF0080";
-        coltwo = "#7928CA";
-    } else {
-        currentCode = "310deg, " + themeConfig.themeColors.primarayColor + " 0%, " + themeConfig.themeColors.secondaryColor + " 100%";
-        colone = themeConfig.themeColors.primarayColor;
-        coltwo = themeConfig.themeColors.secondaryColor;
-    }
-}
 %>
 <meta name="theme-color" content="<%- colone %>">
 <style>


### PR DESCRIPTION
This is my first contribution so please bare with me :D

I thought it might be a cool idea to give users the option to set their own color schemes. I noticed myself that the predefined colors not always match the logos/designs so I had to change them everytime a new version was released.

To enable custom colors you need to set 

`colorScheme: "custom", `

and add the following to the themeConfig.

``` javascript
themeColors: {
                    primaryColor: "#ff0000",
                    secondaryColor: "#ff0000",
                },
```

If a user does not set the themeColors or misses one of the colors the "pink" schema colors will be set.