### PR TITLE
Update guilds.ejs: fix site refresh after guild invite

### DIFF
--- a/views/guilds.ejs
+++ b/views/guilds.ejs
@@ -71,17 +71,19 @@
                                         else icon = icon + "?size=256"
                                     %>
                                     <!--href="../invite?g=<%- req.session.guilds[i].id %>"-->
-                                    <a onclick="const newWindow = window.open(`/invite?g=<%- req.session.guilds[i].id %><%- config.invite?.redirectUri ? `&redirect=${config.invite.redirectUri.replace('{SERVER}', req.session.guilds[i].id)}` : '' %>`, 'Add bot to guild', 'scrollbars=no, resizable=no, status=no, location=no, toolbar=no, menubar=no, width=500, height=800'); checkRefresh()">
+                                    <a onclick="const newWindow = window.open(`/invite?g=<%- req.session.guilds[i].id %><%- config.invite?.redirectUri ? `&redirect=${config.invite.redirectUri.replace('{SERVER}', req.session.guilds[i].id)}` : '' %>`, 'Add bot to guild', 'scrollbars=no, resizable=no, status=no, location=no, toolbar=no, menubar=no, width=500, height=800'); checkRefresh(newWindow)">
                                         <div max="20" scale="110" perspective="700" class="_82d1"
                                              data-guildname="<%- req.session.guilds[i].name %>"
                                              style="background-image: url(&quot;<%- icon %>&quot;); filter: grayscale(1);"></div>
                                     </a>
-
                             <% } } } %>
                             <script>
-                                function checkRefresh() {
-                                    setInterval(() => {
-                                        if (newWindow.closed) location.reload();
+                                function checkRefresh(popup) {
+                                    const interval = setInterval(() => {
+                                        if (popup.closed) {
+                                            clearInterval(interval);
+                                            location.reload();
+                                        }
                                     }, 500);
                                 }
                             </script>


### PR DESCRIPTION
“newWindow” was missing from the checkRefresh() function 

I have also revised the checkRefresh function:

function checkRefresh(popup) {
  const interval = setInterval(() => {
   if (popup.closed) {
   clearInterval(interval);
   location.reload();
  }
 }, 500);
}